### PR TITLE
hash: Mark operator() noexcept where possible

### DIFF
--- a/include/strong_type/strong_type.hpp
+++ b/include/strong_type/strong_type.hpp
@@ -1520,6 +1520,7 @@ struct hash<::strong::type<T, Tag, M...>>
   operator()(
     const ::strong::hashable::modifier<type>& t)
   const
+  noexcept(noexcept(std::declval<hash<T>>()(value_of(std::declval<const type&>()))))
   {
     auto& tt = static_cast<const type&>(t);
     return hash<T>::operator()(value_of(tt));


### PR DESCRIPTION
Found with GCC10 -Wnoexcept