### PR TITLE
strong::formattable modifier added

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,13 @@ can thus be used as key in `std::map`<> or `std::set<>`.
   the iterator types are using the same tag as using in the range. Only
   implements types `iterator` and `const_iterator`, and thus `.begin()`,
   `.end()`, `.cbegin()`, `.cend()`, `.begin() const` and `.end() const`.
-    
+
+* `strong::formattable` adds `std::format` and/or `fmt::format` capability, based
+  on availability of the formatting library. This can further be controlled
+  (globally) with the defines `STRONG_HAS_STD_FORMAT` respectively
+  `STRONG_HAS_FMT_FORMAT`. With 0 to disable the support completly, and with 1 to
+  force the support, disable the auto detection.
+
 For modifier `strong::arithmetic`, the type trait `std::is_arithmetic<>` is true.
 
 For modifier `strong::iterator`, the type trait `std::iterator_traits` mirrors

--- a/test.cpp
+++ b/test.cpp
@@ -1266,3 +1266,22 @@ TEST_CASE("ordered_with")
   REQUIRE(2 > i1);
   REQUIRE_FALSE(1 > i1);
 }
+
+#if STRONG_HAS_STD_FORMAT || STRONG_HAS_FMT_FORMAT
+TEST_CASE("format")
+{
+  using formatint = strong::type<int, struct formattag, strong::formattable>;
+
+  formatint fi{5};
+
+#if STRONG_HAS_FMT_FORMAT
+  CHECK(fmt::format("{:d}", fi) == fmt::format("{:d}", 5));
+  CHECK_THROWS_AS(fmt::format("{:s}", fi), fmt::format_error);
+#endif
+
+#if STRONG_HAS_STD_FORMAT
+  CHECK(std::format("{:d}", fi) == std::format("{:d}", 5));
+  CHECK_THROWS_AS(std::format("{:s}", fi), std::format_error);
+#endif
+}
+#endif


### PR DESCRIPTION
Is the detection fine?
Is the style fine? (A .clang-format would really help! ;))

I've only tested the `fmt::` variant, since I have no `std::format`, but as the API is identical I don't see a problem in also adding the `std::` variant already.