### PR TITLE
Fixed the name of the targets file in the CMake config

### DIFF
--- a/strong_type-config.cmake
+++ b/strong_type-config.cmake
@@ -12,4 +12,4 @@
 #
 
 
-include( "${CMAKE_CURRENT_LIST_DIR}/trompeloeil-targets.cmake" )
+include( "${CMAKE_CURRENT_LIST_DIR}/strong_type-targets.cmake" )


### PR DESCRIPTION
The provided cmake config file tries to include a target called `trompeloeil-targets.cmake`, while the CMakeLists.txt installs the exports as `strong_type-targets.cmake`. This pr fixes that discrepancy.