### PR TITLE
Fix swap noexcept for NVCC

### DIFF
--- a/include/strong_type/strong_type.hpp
+++ b/include/strong_type/strong_type.hpp
@@ -103,8 +103,8 @@ public:
   {}
 
   friend STRONG_CONSTEXPR void swap(type& a, type& b) noexcept(
-                                                        std::is_nothrow_move_constructible<type>::value &&
-                                                        std::is_nothrow_move_assignable<type>::value
+                                                        std::is_nothrow_move_constructible<T>::value &&
+                                                        std::is_nothrow_move_assignable<T>::value
                                                       )
   {
     using std::swap;


### PR DESCRIPTION
NVCC appears to evaluate the body of a `noexcept(...)` before completing a type, which causes it to fail on strong types:
https://cuda.godbolt.org/z/zvrrozMPb
https://cuda.godbolt.org/z/MfMdndxsY

Every other compiler I tried allowed it so my guess it that it's a bug in NVCC; however considering swap is just using `val` directly it seems sufficient to just check against `T`. (And it's cleaner than adding an `#if defined(__CUDACC__)`)