### PR TITLE
Add missing include

### DIFF
--- a/include/strong_type/strong_type.hpp
+++ b/include/strong_type/strong_type.hpp
@@ -59,6 +59,10 @@
 
 #if STRONG_HAS_FMT_FORMAT
 #include <fmt/format.h>
+
+#if FMT_VERSION >= 90000
+#include <fmt/ostream.h>
+#endif
 #endif
 
 namespace strong


### PR DESCRIPTION
To use fmt::ostream_formatter one has to include <fmt/ostream.h>, which was missing here.