### PR TITLE
Fix typo in MSVC version check

### DIFF
--- a/include/strong_type/strong_type.hpp
+++ b/include/strong_type/strong_type.hpp
@@ -26,7 +26,7 @@
 #define STRONG_NODISCARD
 #endif
 
-#if defined(_MSC_VER) && !defined(__clang__) && __MSC_VER < 1922
+#if defined(_MSC_VER) && !defined(__clang__) && _MSC_VER < 1922
 #define STRONG_CONSTEXPR
 #else
 #define STRONG_CONSTEXPR constexpr


### PR DESCRIPTION
constexpr macro was defined incorrectly due to an extra underscore.