### PR TITLE
feat: make strong types usable as non-type template parameter

### DIFF
--- a/include/strong_type/type.hpp
+++ b/include/strong_type/type.hpp
@@ -141,9 +141,6 @@ public:
     friend constexpr const T &&value_of(const type &&t) noexcept
     { return std::move(t)._val; }
 
-#if __cpp_nontype_template_args < 201911L
-  private:
-#endif
     T _val;
 };
 

--- a/include/strong_type/type.hpp
+++ b/include/strong_type/type.hpp
@@ -73,7 +73,7 @@ public:
     constexpr
     type()
     noexcept(noexcept(T{}))
-        : val{}
+        : _val{}
     {
     }
 
@@ -85,7 +85,7 @@ public:
         std::initializer_list<U> us
     )
     noexcept(noexcept(T{us}))
-        : val{us}
+        : _val{us}
     {
     }
 
@@ -97,7 +97,7 @@ public:
     type(
         U &&... u)
     noexcept(std::is_nothrow_constructible<T, U...>::value)
-        : val(std::forward<U>(u)...)
+        : _val(std::forward<U>(u)...)
     {}
 
     friend STRONG_CONSTEXPR void swap(type &a, type &b) noexcept(
@@ -106,43 +106,45 @@ public:
     )
     {
         using std::swap;
-        swap(a.val, b.val);
+        swap(a._val, b._val);
     }
 
     STRONG_NODISCARD
     constexpr T &value_of() & noexcept
-    { return val; }
+    { return _val; }
 
     STRONG_NODISCARD
     constexpr const T &value_of() const & noexcept
-    { return val; }
+    { return _val; }
 
     STRONG_NODISCARD
     constexpr T &&value_of() && noexcept
-    { return std::move(val); }
+    { return std::move(_val); }
 
     STRONG_NODISCARD
     constexpr const T &&value_of() const && noexcept
-    { return std::move(val); }
+    { return std::move(_val); }
 
     STRONG_NODISCARD
     friend constexpr T &value_of(type &t) noexcept
-    { return t.val; }
+    { return t._val; }
 
     STRONG_NODISCARD
     friend constexpr const T &value_of(const type &t) noexcept
-    { return t.val; }
+    { return t._val; }
 
     STRONG_NODISCARD
     friend constexpr T &&value_of(type &&t) noexcept
-    { return std::move(t).val; }
+    { return std::move(t)._val; }
 
     STRONG_NODISCARD
     friend constexpr const T &&value_of(const type &&t) noexcept
-    { return std::move(t).val; }
+    { return std::move(t)._val; }
 
-private:
-    T val;
+#if __cpp_nontype_template_args < 201911L
+  private:
+#endif
+    T _val;
 };
 
 namespace impl {

--- a/test/test_type.cpp
+++ b/test/test_type.cpp
@@ -244,7 +244,7 @@ template <auto> class foo {};
 TEST_CASE("value can be used as non-type template parameter") {
 
     using strong_int = strong::type<int, struct si_>;
-    foo<strong_int{5}> foo;
+    [[maybe_unused]] foo<strong_int{5}> foo;
 }
 
 #endif

--- a/test/test_type.cpp
+++ b/test/test_type.cpp
@@ -241,8 +241,8 @@ TEST_CASE("swap")
 
 template <auto> class foo {};
 
-TEST_CASE("value can be used as non-type template parameter") {
-
+TEST_CASE("value can be used as non-type template parameter")
+{
     using strong_int = strong::type<int, struct si_>;
     [[maybe_unused]] foo<strong_int{5}> foo;
 }

--- a/test/test_type.cpp
+++ b/test/test_type.cpp
@@ -237,7 +237,8 @@ TEST_CASE("swap")
     CHECK(v2.value_of() == 6);
 }
 
-#if __cpp_nontype_template_args >= 201911L
+#if (__cpp_nontype_template_args >= 201911L) || \
+  (__cpp_nontype_template_args >= 201411 && __clang_major__ >= 12)
 
 template <auto> class foo {};
 

--- a/test/test_type.cpp
+++ b/test/test_type.cpp
@@ -237,3 +237,14 @@ TEST_CASE("swap")
     CHECK(v2.value_of() == 6);
 }
 
+#if __cpp_nontype_template_args >= 201911L
+
+template <auto> class foo {};
+
+TEST_CASE("value can be used as non-type template parameter") {
+
+    using strong_int = strong::type<int, struct si_>;
+    foo<strong_int{5}> foo;
+}
+
+#endif

--- a/test/test_type.cpp
+++ b/test/test_type.cpp
@@ -238,7 +238,7 @@ TEST_CASE("swap")
 }
 
 #if (__cpp_nontype_template_args >= 201911L) || \
-  (__cpp_nontype_template_args >= 201411 && __clang_major__ >= 12)
+  (__cplusplus >= 202002 && __cpp_nontype_template_args >= 201411 && __clang_major__ >= 12)
 
 template <auto> class foo {};
 


### PR DESCRIPTION
This PR makes the variable `val` (renamed to `_val`) public visible to make it a literal class type (structural).

See https://en.cppreference.com/w/cpp/language/template_parameters
> a [literal class type](https://en.cppreference.com/w/cpp/named_req/LiteralType) with the following properties:
> * all base classes and non-static data members are public and non-mutable and
> * the types of all base classes and non-static data members are structural types or (possibly multi-dimensional) array thereof.


The issue is really bumping me (and my colleagues). We cannot use strong_type inside templates...

Without the change the extended test in `test_type.cpp` fails with:

```
<...>/strong_type/test/test_type.cpp: In function ‘void C_A_T_C_H_T_E_S_T_52()’:
<...>/strong_type/test/test_type.cpp:191:20: error: ‘strong::type<int, C_A_T_C_H_T_E_S_T_52()::si_>’ is not a valid type for a template non-type parameter because it is not structural
  191 |   foo<strong_int{5}> foo;
      |                    ^
In file included from <...>/strong_type/test/test_type.cpp:14:
<...>/strong_type/include/strong_type/type.hpp:145:7: note: ‘strong::type<int, C_A_T_C_H_T_E_S_T_52()::si_>::val’ is not public
  145 |     T val;
      |       ^~~
```