### PR TITLE
fmt: make `formatter::format` const

### DIFF
--- a/include/strong_type/formattable.hpp
+++ b/include/strong_type/formattable.hpp
@@ -75,6 +75,15 @@ struct formatter<::strong::type<T, Tag, M...>, Char> : formatter<T, Char>
   template<typename FormatContext, typename Type>
   STRONG_CONSTEXPR
   decltype(auto)
+  format(const Type& t, FormatContext& fc) const
+      noexcept(noexcept(std::declval<formatter<T, Char>>().format(std::declval<const T&>(), fc)))
+  {
+    return formatter<T, Char>::format(value_of(t), fc);
+  }
+
+  template<typename FormatContext, typename Type>
+  STRONG_CONSTEXPR
+  decltype(auto)
   format(const Type& t, FormatContext& fc)
       noexcept(noexcept(std::declval<formatter<T, Char>>().format(std::declval<const T&>(), fc)))
   {
@@ -94,6 +103,15 @@ struct formatter;
 template <typename T, typename Tag, typename ... M, typename Char>
 struct formatter<type<T, Tag, M...>, Char> : fmt::formatter<T, Char>
 {
+  template<typename FormatContext, typename Type>
+  STRONG_CONSTEXPR
+  decltype(auto)
+  format(const Type& t, FormatContext& fc) const
+      noexcept(noexcept(std::declval<fmt::formatter<T, Char>>().format(std::declval<const T&>(), fc)))
+  {
+    return fmt::formatter<T, Char>::format(value_of(t), fc);
+  }
+
   template<typename FormatContext, typename Type>
   STRONG_CONSTEXPR
   decltype(auto)


### PR DESCRIPTION
i guess it's safe to assume that `format` **has** to be a const function:

`fmt/ranges.h` contains:
```
  template <typename T>
  void operator()(const formatter<T, char_type>& f, const T& v) {
    if (i > 0)
      ctx.advance_to(detail::copy_str<char_type>(separator, ctx.out()));
    ctx.advance_to(f.format(v, ctx));
    ++i;
  }
```

where the formatter is passed as `const&`