### PR TITLE
Draft: Make uninitialized constructor constexpr

### DIFF
--- a/include/strong_type/type.hpp
+++ b/include/strong_type/type.hpp
@@ -62,7 +62,11 @@ template<typename T, typename Tag, typename ... M>
 class type : public modifier<M, type<T, Tag, M...>> ... {
 public:
     template<typename TT = T, typename = std::enable_if_t<std::is_trivially_constructible<TT>{}>>
-    explicit type(uninitialized_t)
+    constexpr
+    explicit
+    type(
+        uninitialized_t
+    )
     noexcept
     {
     }

--- a/test/test_type.cpp
+++ b/test/test_type.cpp
@@ -19,6 +19,12 @@
 
 #include <memory>
 
+TEST_CASE("Uninitialized construction")
+{
+    STATIC_REQUIRE(std::is_trivially_constructible<int>);
+    constexpr strong::type<int, struct i_> vc(strong::uninitialized);
+    strong::type<int, struct i_> vr(strong::uninitialized);
+}
 
 TEST_CASE("default_constructible initializes with underlying default constructor")
 {


### PR DESCRIPTION
Hi,

until now the "uninitialized constructor" could not be executed in const expressions.
This MR does change this (and yes uninitialized construction is an odd edge case in strong_type anyways ;) ).

Sorry, I am not familiar with your coding convention. Did I format the code correctly? Please change at will.

Best regards,
sparkles