### PR TITLE
Make CMake package version ARCH_INDEPENDENT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 #
 
 
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.14)
 project(strong_type)
 
 include(GNUInstallDirs)
@@ -34,7 +34,8 @@ endif()
 write_basic_package_version_file(
   "${CMAKE_CURRENT_BINARY_DIR}/strong_type/strong_type-config-version.cmake"
   VERSION ${STRONG_TYPE_VERSION}
-  COMPATIBILITY AnyNewerVersion)
+  COMPATIBILITY AnyNewerVersion
+  ARCH_INDEPENDENT)
 
 add_library(strong_type INTERFACE)
 add_library(strong_type::strong_type ALIAS strong_type)
@@ -84,4 +85,3 @@ install(
   DESTINATION
     "${CMAKE_INSTALL_INCLUDEDIR}/strong_type"
 )
-


### PR DESCRIPTION
Since strong_type is a header-only library, its package version should be considered compatible independent of the target architecture. The `ARCH_INDEPENDENT` option of `write_basic_package_version_file()` ensures just that. See [the documentation](https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html#command:write_basic_package_version_file) for more details.

Note that using `ARCH_INDEPENDENT` increases the minimum required CMake version to 3.14. Given how easy it is to get the latest CMake version on any platform, this should not be an issue, though (see the table under "Picking a CMake Version" of [this blog post](https://alexreinking.com/blog/how-to-use-cmake-without-the-agonizing-pain-part-1.html)).