### PR TITLE
strong_ordering: Fix Typo

### DIFF
--- a/include/strong_type/strong_ordering.hpp
+++ b/include/strong_type/strong_ordering.hpp
@@ -23,7 +23,7 @@ public:
     STRONG_CONSTEXPR
     std::strong_ordering operator<=>(const type& lh, const type& rh) noexcept
     {
-      return value_of(lh) <=> alue_of(rh);
+      return value_of(lh) <=> value_of(rh);
     }
 };
 }


### PR DESCRIPTION
Apparently not used in the tests. I currently have no time to add some.