### PR TITLE
Add the STRONG_TYPE_MODULE_EXPORT to all entities that should be exported, aka strong_type module part 1

### DIFF
--- a/include/strong_type/affine_point.hpp
+++ b/include/strong_type/affine_point.hpp
@@ -18,7 +18,7 @@
 
 namespace strong
 {
-template <typename D = void>
+STRONG_TYPE_MODULE_EXPORT template <typename D = void>
 struct affine_point
 {
     template <typename T>
@@ -36,6 +36,7 @@ struct subtractable<T, void_t<decltype(std::declval<const T&>() - std::declval<c
 }
 
 
+STRONG_TYPE_MODULE_EXPORT
 template <typename D>
 template <typename T, typename Tag, typename ... M>
 class affine_point<D>::modifier<::strong::type<T, Tag, M...>>

--- a/include/strong_type/arithmetic.hpp
+++ b/include/strong_type/arithmetic.hpp
@@ -20,7 +20,7 @@
 
 namespace strong
 {
-struct arithmetic {
+STRONG_TYPE_MODULE_EXPORT struct arithmetic {
     template<typename T, typename = void>
     class modifier
     {
@@ -29,7 +29,7 @@ struct arithmetic {
     };
 };
 
-template <typename T, typename Tag, typename ... Ms>
+STRONG_TYPE_MODULE_EXPORT template <typename T, typename Tag, typename ... Ms>
 class arithmetic::modifier<strong::type<T, Tag, Ms...>, impl::void_t<decltype(std::declval<T>() * std::declval<T>() - std::declval<T>() / std::declval<T>())>>
 {
     using type = strong::type<T, Tag, Ms...>;
@@ -170,7 +170,7 @@ public:
 
 }
 
-template <typename T, typename Tag, typename ... Ms>
+STRONG_TYPE_MODULE_EXPORT template <typename T, typename Tag, typename ... Ms>
 #if defined(__cpp_concepts)
 requires strong::type_is_v<strong::type<T, Tag, Ms...>, strong::arithmetic>
 class std::numeric_limits<strong::type<T, Tag, Ms...>>

--- a/include/strong_type/bicrementable.hpp
+++ b/include/strong_type/bicrementable.hpp
@@ -19,7 +19,7 @@
 
 namespace strong
 {
-struct bicrementable
+STRONG_TYPE_MODULE_EXPORT struct bicrementable
 {
     template <typename T>
     class modifier

--- a/include/strong_type/bitarithmetic.hpp
+++ b/include/strong_type/bitarithmetic.hpp
@@ -18,7 +18,7 @@
 
 namespace strong
 {
-struct bitarithmetic
+STRONG_TYPE_MODULE_EXPORT struct bitarithmetic
 {
     template <typename T, typename = void>
     class modifier

--- a/include/strong_type/boolean.hpp
+++ b/include/strong_type/boolean.hpp
@@ -18,7 +18,7 @@
 
 namespace strong
 {
-struct boolean
+STRONG_TYPE_MODULE_EXPORT struct boolean
 {
     template <typename T, typename = void>
     class modifier

--- a/include/strong_type/convertible_to.hpp
+++ b/include/strong_type/convertible_to.hpp
@@ -43,7 +43,7 @@ struct converter<
 
 }
 
-template <typename ... Ts>
+STRONG_TYPE_MODULE_EXPORT template <typename ... Ts>
 struct convertible_to
 {
     template <typename T>

--- a/include/strong_type/decrementable.hpp
+++ b/include/strong_type/decrementable.hpp
@@ -18,7 +18,7 @@
 
 namespace strong
 {
-struct decrementable
+STRONG_TYPE_MODULE_EXPORT struct decrementable
 {
     template <typename T, typename = void>
     class modifier

--- a/include/strong_type/difference.hpp
+++ b/include/strong_type/difference.hpp
@@ -85,13 +85,13 @@ public:
     }
 };
 }
-struct difference
+STRONG_TYPE_MODULE_EXPORT struct difference
 {
     template <typename T>
     class modifier;
 };
 
-template <typename T, typename Tag, typename ... M>
+STRONG_TYPE_MODULE_EXPORT template <typename T, typename Tag, typename ... M>
 class difference::modifier<::strong::type<T, Tag, M...>>
     : public impl::conditionally_ordered::modifier<::strong::type<T, Tag, M...>>
     , public equality::modifier<::strong::type<T, Tag, M...>>

--- a/include/strong_type/equality.hpp
+++ b/include/strong_type/equality.hpp
@@ -18,7 +18,7 @@
 
 namespace strong
 {
-struct equality
+STRONG_TYPE_MODULE_EXPORT struct equality
 {
     template <typename T, typename = void>
     class modifier {
@@ -28,7 +28,7 @@ struct equality
 };
 
 
-template <typename T, typename Tag, typename ... M>
+STRONG_TYPE_MODULE_EXPORT template <typename T, typename Tag, typename ... M>
 class equality::modifier<
     ::strong::type<T, Tag, M...>,
     impl::void_t<decltype(std::declval<const T&>() == std::declval<const T&>())>

--- a/include/strong_type/equality_with.hpp
+++ b/include/strong_type/equality_with.hpp
@@ -76,7 +76,7 @@ public:
 };
 }
 
-template <typename ... Ts>
+STRONG_TYPE_MODULE_EXPORT template <typename ... Ts>
 struct equality_with
 {
     template <typename T>

--- a/include/strong_type/formattable.hpp
+++ b/include/strong_type/formattable.hpp
@@ -51,7 +51,7 @@
 namespace strong
 {
 
-struct formattable
+STRONG_TYPE_MODULE_EXPORT struct formattable
 {
     template <typename T>
     class modifier{};

--- a/include/strong_type/hashable.hpp
+++ b/include/strong_type/hashable.hpp
@@ -20,7 +20,7 @@
 
 namespace strong
 {
-struct hashable
+STRONG_TYPE_MODULE_EXPORT struct hashable
 {
     template <typename T>
     class modifier{};
@@ -29,7 +29,7 @@ struct hashable
 }
 
 namespace std {
-template<typename T, typename Tag, typename ... M>
+STRONG_TYPE_MODULE_EXPORT template<typename T, typename Tag, typename ... M>
 struct hash<::strong::type<T, Tag, M...>>
     : std::conditional_t<
         std::is_base_of<

--- a/include/strong_type/implicitly_convertible_to.hpp
+++ b/include/strong_type/implicitly_convertible_to.hpp
@@ -42,7 +42,7 @@ struct implicit_converter<
 };
 }
 
-template <typename ... Ts>
+STRONG_TYPE_MODULE_EXPORT template <typename ... Ts>
 struct implicitly_convertible_to
 {
     template <typename T>

--- a/include/strong_type/incrementable.hpp
+++ b/include/strong_type/incrementable.hpp
@@ -17,7 +17,7 @@
 #include "type.hpp"
 
 namespace strong {
-struct incrementable
+STRONG_TYPE_MODULE_EXPORT struct incrementable
 {
     template <typename T, typename = void>
     class modifier

--- a/include/strong_type/indexed.hpp
+++ b/include/strong_type/indexed.hpp
@@ -18,7 +18,7 @@
 
 namespace strong
 {
-template <typename I = void>
+STRONG_TYPE_MODULE_EXPORT template <typename I = void>
 struct indexed
 {
     template <typename T, typename = void>
@@ -29,7 +29,7 @@ struct indexed
     };
 };
 
-template <>
+STRONG_TYPE_MODULE_EXPORT template <>
 struct indexed<void> {
     template<typename>
     class modifier;
@@ -112,7 +112,7 @@ struct indexed<void> {
     };
 };
 
-template <typename I>
+STRONG_TYPE_MODULE_EXPORT template <typename I>
 template <typename T, typename Tag, typename ... M>
 class indexed<I>::modifier<
     type<T, Tag, M...>,

--- a/include/strong_type/invocable.hpp
+++ b/include/strong_type/invocable.hpp
@@ -20,13 +20,13 @@
 namespace strong
 {
 
-struct invocable
+STRONG_TYPE_MODULE_EXPORT struct invocable
 {
     template <typename>
     class modifier;
 };
 
-template <typename T, typename Tag, typename ... Ms>
+STRONG_TYPE_MODULE_EXPORT template <typename T, typename Tag, typename ... Ms>
 class invocable::modifier<type<T, Tag, Ms...>>
 {
     using type = strong::type<T, Tag, Ms...>;

--- a/include/strong_type/iostreamable.hpp
+++ b/include/strong_type/iostreamable.hpp
@@ -19,7 +19,7 @@
 
 namespace strong
 {
-struct iostreamable
+STRONG_TYPE_MODULE_EXPORT struct iostreamable
 {
     template <typename T>
     class modifier

--- a/include/strong_type/istreamable.hpp
+++ b/include/strong_type/istreamable.hpp
@@ -20,7 +20,7 @@
 
 namespace strong
 {
-struct istreamable
+STRONG_TYPE_MODULE_EXPORT struct istreamable
 {
     template <typename T, typename = void>
     class  modifier

--- a/include/strong_type/iterator.hpp
+++ b/include/strong_type/iterator.hpp
@@ -64,7 +64,7 @@ namespace internal {
 
     };
 }
-class iterator
+STRONG_TYPE_MODULE_EXPORT class iterator
 {
 public:
     template <typename I,

--- a/include/strong_type/ordered.hpp
+++ b/include/strong_type/ordered.hpp
@@ -21,7 +21,7 @@
 #endif
 namespace strong
 {
-struct ordered
+STRONG_TYPE_MODULE_EXPORT struct ordered
 {
     template <typename T, typename = void>
     class modifier
@@ -31,7 +31,7 @@ struct ordered
     };
 };
 
-
+STRONG_TYPE_MODULE_EXPORT
 template <typename T, typename Tag, typename ... M>
 class ordered::modifier<
     ::strong::type<T, Tag, M...>,
@@ -108,7 +108,7 @@ struct spaceship_ordering {
     struct modifier;
 };
 
-template<typename Ordering>
+STRONG_TYPE_MODULE_EXPORT template<typename Ordering>
 template<typename T, typename Tag, typename ... Ms>
 struct spaceship_ordering<Ordering>::modifier<::strong::type<T, Tag, Ms...>>
 {
@@ -131,9 +131,9 @@ struct spaceship_ordering<Ordering>::modifier<::strong::type<T, Tag, Ms...>>
 
 }
 
-using strongly_ordered = detail::spaceship_ordering<std::strong_ordering>;
-using weakly_ordered = detail::spaceship_ordering<std::weak_ordering>;
-using partially_ordered = detail::spaceship_ordering<std::partial_ordering>;
+STRONG_TYPE_MODULE_EXPORT using strongly_ordered = detail::spaceship_ordering<std::strong_ordering>;
+STRONG_TYPE_MODULE_EXPORT using weakly_ordered = detail::spaceship_ordering<std::weak_ordering>;
+STRONG_TYPE_MODULE_EXPORT using partially_ordered = detail::spaceship_ordering<std::partial_ordering>;
 
 #endif
 

--- a/include/strong_type/ordered_with.hpp
+++ b/include/strong_type/ordered_with.hpp
@@ -125,7 +125,7 @@ public:
 };
 }
 
-template <typename ... Ts>
+STRONG_TYPE_MODULE_EXPORT template <typename ... Ts>
 struct ordered_with
 {
     template <typename T>
@@ -171,11 +171,11 @@ struct spaceship_ordering_with
 
 }
 
-template <typename ... Ts>
+STRONG_TYPE_MODULE_EXPORT template <typename ... Ts>
 using strongly_ordered_with = detail::spaceship_ordering_with<std::strong_ordering, Ts...>;
-template <typename ... Ts>
+STRONG_TYPE_MODULE_EXPORT template <typename ... Ts>
 using weakly_ordered_with = detail::spaceship_ordering_with<std::weak_ordering, Ts...>;
-template <typename ... Ts>
+STRONG_TYPE_MODULE_EXPORT template <typename ... Ts>
 using partially_ordered_with = detail::spaceship_ordering_with<std::partial_ordering, Ts...>;
 
 #endif

--- a/include/strong_type/ostreamable.hpp
+++ b/include/strong_type/ostreamable.hpp
@@ -20,7 +20,7 @@
 
 namespace strong
 {
-struct ostreamable
+STRONG_TYPE_MODULE_EXPORT struct ostreamable
 {
     template <typename T, typename = void>
     class modifier
@@ -43,7 +43,7 @@ struct ostreamable
     };
 };
 
-template<typename T>
+STRONG_TYPE_MODULE_EXPORT template<typename T>
 using is_ostreamable = std::is_base_of<ostreamable::modifier<T>, T>;
 
 }

--- a/include/strong_type/pointer.hpp
+++ b/include/strong_type/pointer.hpp
@@ -18,19 +18,19 @@
 
 namespace strong
 {
-struct pointer
+STRONG_TYPE_MODULE_EXPORT struct pointer
 {
     template <typename T, typename = void>
     class modifier;
 };
 
-template <typename T>
+STRONG_TYPE_MODULE_EXPORT template <typename T>
 class pointer::modifier<T, void>
 {
   static_assert(impl::always_false<T>, "Underlying type must support dereferencing with operator*");
 };
 
-template <typename T, typename Tag, typename ... M>
+STRONG_TYPE_MODULE_EXPORT template <typename T, typename Tag, typename ... M>
 class pointer::modifier<::strong::type<T, Tag, M...>, impl::void_t<decltype(*std::declval<T>())>>
 {
     using type = strong::type<T, Tag, M...>;

--- a/include/strong_type/range.hpp
+++ b/include/strong_type/range.hpp
@@ -128,7 +128,7 @@ constexpr bool is_random_access(std::output_iterator_tag) { return false;}
 #define STRONG_TYPE_CEND(x) x.cend()
 #endif
 
-class range
+STRONG_TYPE_MODULE_EXPORT class range
 {
 public:
     template <
@@ -142,7 +142,7 @@ public:
     class modifier;
 };
 
-template <typename R>
+STRONG_TYPE_MODULE_EXPORT template <typename R>
 class range::modifier<
         R,
         internal::not_an_iterator, internal::not_an_iterator,
@@ -155,7 +155,7 @@ class range::modifier<
 
 };
 
-template <typename T, typename Tag, typename ... M, typename iterator>
+STRONG_TYPE_MODULE_EXPORT template <typename T, typename Tag, typename ... M, typename iterator>
 class range::modifier<
         type<T, Tag, M...>,
         iterator, iterator,
@@ -165,7 +165,7 @@ class range::modifier<
     static_assert(impl::always_false<T>, "the underlying type is lying about its iterator type");
 };
 
-template <typename T, typename Tag, typename ... M, typename r_iterator, typename r_const_iterator>
+STRONG_TYPE_MODULE_EXPORT template <typename T, typename Tag, typename ... M, typename r_iterator, typename r_const_iterator>
 class range::modifier<
     type<T, Tag, M...>,
     r_iterator, r_iterator,
@@ -260,7 +260,7 @@ public:
     }
 };
 
-template <typename T, typename Tag, typename ... M, typename r_iterator, typename r_const_iterator, typename r_sentinel>
+STRONG_TYPE_MODULE_EXPORT template <typename T, typename Tag, typename ... M, typename r_iterator, typename r_const_iterator, typename r_sentinel>
 class range::modifier<
         type<T, Tag, M...>,
         r_iterator, r_sentinel,
@@ -356,7 +356,7 @@ public:
     }
 };
 
-template <typename T, typename Tag, typename ... M, typename r_iterator>
+STRONG_TYPE_MODULE_EXPORT template <typename T, typename Tag, typename ... M, typename r_iterator>
 class range::modifier<
             type<T, Tag, M...>,
             r_iterator, r_iterator,
@@ -401,7 +401,7 @@ class range::modifier<
     }
 };
 
-template <typename T, typename Tag, typename ... M, typename r_iterator, typename r_sentinel>
+STRONG_TYPE_MODULE_EXPORT template <typename T, typename Tag, typename ... M, typename r_iterator, typename r_sentinel>
 class range::modifier<
         type<T, Tag, M...>,
         r_iterator, r_sentinel,
@@ -447,7 +447,7 @@ public:
     }
 };
 
-template <typename T, typename Tag, typename ... M, typename r_const_iterator, typename r_sentinel>
+STRONG_TYPE_MODULE_EXPORT template <typename T, typename Tag, typename ... M, typename r_const_iterator, typename r_sentinel>
 class range::modifier<
         type<T, Tag, M...>,
         internal::not_an_iterator, internal::not_an_iterator,

--- a/include/strong_type/regular.hpp
+++ b/include/strong_type/regular.hpp
@@ -19,7 +19,7 @@
 
 namespace strong
 {
-struct regular
+STRONG_TYPE_MODULE_EXPORT struct regular
 {
     template <typename T>
     class modifier

--- a/include/strong_type/scalable_with.hpp
+++ b/include/strong_type/scalable_with.hpp
@@ -103,7 +103,7 @@ public:
 };
 }
 
-template <typename ... Ts>
+STRONG_TYPE_MODULE_EXPORT template <typename ... Ts>
 struct scalable_with
 {
     template <typename T>
@@ -115,7 +115,7 @@ struct scalable_with
 };
 }
 
-template <
+STRONG_TYPE_MODULE_EXPORT template <
     typename TT,
     typename UT = strong::underlying_type_t<TT>,
     typename R = typename TT::scalable_modifier_result_type,

--- a/include/strong_type/semiregular.hpp
+++ b/include/strong_type/semiregular.hpp
@@ -31,13 +31,13 @@ struct require_semiregular
 };
 
 }
-struct semiregular
+STRONG_TYPE_MODULE_EXPORT struct semiregular
 {
     template <typename>
     class modifier;
 };
 
-template <typename T, typename Tag, typename ... M>
+STRONG_TYPE_MODULE_EXPORT template <typename T, typename Tag, typename ... M>
 class semiregular::modifier<::strong::type<T, Tag, M...>>
     : public default_constructible::modifier<T>
         , private impl::require_semiregular<T>

--- a/include/strong_type/strong_ordering.hpp
+++ b/include/strong_type/strong_ordering.hpp
@@ -7,13 +7,13 @@
 
 namespace strong
 {
-struct strong_ordering
+STRONG_TYPE_MODULE_EXPORT struct strong_ordering
 {
     template <typename T>
     class modifier;
 };
 
-template <typename T, typename Tag, typename ... M>
+STRONG_TYPE_MODULE_EXPORT template <typename T, typename Tag, typename ... M>
 class strong_ordering::modifier<::strong::type<T, Tag, M...>>
 {
     using type = ::strong::type<T, Tag, M...>;

--- a/include/strong_type/strong_type.ixx
+++ b/include/strong_type/strong_type.ixx
@@ -1,0 +1,57 @@
+/*
+ * strong_type C++14/17/20 strong typedef library
+ *
+ * Copyright (C) Björn Fahller
+ *
+ *  Use, modification and distribution is subject to the
+ *  Boost Software License, Version 1.0. (See accompanying
+ *  file LICENSE_1_0.txt or copy at
+ *  http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * Project home: https://github.com/rollbear/strong_type
+ */
+
+module;
+
+#include <version>
+
+#define STRONG_TYPE_MODULE
+#define STRONG_TYPE_MODULE_EXPORT export
+#define STRONG_TYPE_IMPORT_STD_LIBRARY
+
+export module strong_type;
+
+// Currently this just uses the std library module. This should be changed to allow the strong_type module to optionally use
+// inport or include of the standard library
+import std;
+
+#include "affine_point.hpp"
+#include "arithmetic.hpp"
+#include "bicrementable.hpp"
+#include "bitarithmetic.hpp"
+#include "boolean.hpp"
+#include "convertible_to.hpp"
+#include "decrementable.hpp"
+#include "difference.hpp"
+#include "equality.hpp"
+#include "equality_with.hpp"
+#include "formattable.hpp"
+#include "hashable.hpp"
+#include "implicitly_convertible_to.hpp"
+#include "incrementable.hpp"
+#include "indexed.hpp"
+#include "invocable.hpp"
+#include "iostreamable.hpp"
+#include "istreamable.hpp"
+#include "iterator.hpp"
+#include "ordered.hpp"
+#include "ordered_with.hpp"
+#include "ostreamable.hpp"
+#include "pointer.hpp"
+#include "range.hpp"
+#include "regular.hpp"
+#include "scalable_with.hpp"
+#include "semiregular.hpp"
+#include "strong_ordering.hpp"
+#include "type.hpp"
+#include "unique.hpp"

--- a/include/strong_type/type.hpp
+++ b/include/strong_type/type.hpp
@@ -31,16 +31,21 @@
 #define STRONG_NODISCARD
 #endif
 
-namespace strong {
-struct uninitialized_t {
-};
-static constexpr uninitialized_t uninitialized{};
+// For users including rather than importing the header we don't want to force them to define STRONG_TYPE_MODULE_EXPORT so if not defined  define it to be empty
+#if !defined(STRONG_TYPE_MODULE_EXPORT)
+#define STRONG_TYPE_MODULE_EXPORT
+#endif
 
-template<typename M, typename T>
+namespace strong {
+STRONG_TYPE_MODULE_EXPORT struct uninitialized_t {
+};
+STRONG_TYPE_MODULE_EXPORT constexpr uninitialized_t uninitialized{};
+
+STRONG_TYPE_MODULE_EXPORT template<typename M, typename T>
 using modifier = typename M::template modifier<T>;
 
 
-struct default_constructible {
+STRONG_TYPE_MODULE_EXPORT struct default_constructible {
     template<typename T>
     class modifier {
     };
@@ -58,7 +63,7 @@ template<typename T, typename ... V>
 using WhenConstructible = std::enable_if_t<std::is_constructible<T, V...>::value>;
 }
 
-template<typename T, typename Tag, typename ... M>
+STRONG_TYPE_MODULE_EXPORT template<typename T, typename Tag, typename ... M>
 class type : public modifier<M, type<T, Tag, M...>> ... {
 public:
     template<typename TT = T, typename = std::enable_if_t<std::is_trivially_constructible<TT>{}>>
@@ -157,23 +162,23 @@ constexpr T underlying_type(strong::type<T, Tag, Ms...> *);
 
 }
 
-template<typename T>
+STRONG_TYPE_MODULE_EXPORT template<typename T>
 struct is_strong_type : std::integral_constant<bool, impl::is_strong_type_func(
     static_cast<T *>(nullptr))> {
 };
 
 
-template<typename T, bool = is_strong_type<T>::value>
+STRONG_TYPE_MODULE_EXPORT template<typename T, bool = is_strong_type<T>::value>
 struct underlying_type {
     using type = decltype(impl::underlying_type(static_cast<T *>(nullptr)));
 };
 
-template<typename T>
+STRONG_TYPE_MODULE_EXPORT template<typename T>
 struct underlying_type<T, false> {
     using type = T;
 };
 
-template<typename T>
+STRONG_TYPE_MODULE_EXPORT template<typename T>
 using underlying_type_t = typename underlying_type<T>::type;
 
 namespace impl {
@@ -182,7 +187,8 @@ using WhenStrongType = std::enable_if_t<is_strong_type<std::decay_t<T>>::value>;
 template<typename T>
 using WhenNotStrongType = std::enable_if_t<!is_strong_type<std::decay_t<T>>::value>;
 
-template<
+// This is used in the implementation of public functions so must be exported
+STRONG_TYPE_MODULE_EXPORT template<
     typename T,
     typename = impl::WhenNotStrongType<T>>
 constexpr
@@ -193,7 +199,8 @@ noexcept
     return std::forward<T>(t);
 }
 
-template<
+// This is used in the implementation of public functions so must be exported
+STRONG_TYPE_MODULE_EXPORT template<
     typename T,
     typename = impl::WhenStrongType<T>>
 STRONG_NODISCARD
@@ -354,10 +361,10 @@ template <typename T>
 using get_strong = decltype(get_strong_(static_cast<T*>(nullptr)));
 }
 
-template <typename T, typename M>
-static constexpr bool type_is_v = impl::type_is<impl::get_strong<T>, M>;
+STRONG_TYPE_MODULE_EXPORT template <typename T, typename M>
+constexpr bool type_is_v = impl::type_is<impl::get_strong<T>, M>;
 
-template <typename T, typename M>
+STRONG_TYPE_MODULE_EXPORT template <typename T, typename M>
 using type_is = std::integral_constant<bool, type_is_v<T,M>>;
 
 }

--- a/include/strong_type/unique.hpp
+++ b/include/strong_type/unique.hpp
@@ -18,7 +18,7 @@
 
 namespace strong {
 
-struct unique {
+STRONG_TYPE_MODULE_EXPORT struct unique {
     template<typename T>
     class modifier
         : private impl::valid_type<


### PR DESCRIPTION
Add a macro STRONG_TYPE_MODULE_EXPORT.
This at some point will expand to `export` in a module build and empty in a non module build.
Only entities in the strong_type namespace were decorated, anything in "impl", "detail" etc... namespaces were not, although see below.

The header file `type.hpp` contains
```
#if !defined(STRONG_TYPE_MODULE_EXPORT)
#define STRONG_TYPE_MODULE_EXPORT
#endif
```
This allows existing include users to carry on including without any changes

There should be no other changed in this patch. In my local build I have built a module and built all the test cases against it, at least on MSVC. In doing this there were two methods called `access` in the type.hpp header that are used in the implementation of other exported stuff so they had to be exported.

I included the strong_type.ixx file just for you interest, it will probably change a bit from this. I believe that all the other changes in the library header files are messing around with `#include` stuff by macroing them in or out as necessary. 

These changes should not overlap at all with the `import std;` pull request so could be applied in either order.

