### PR TITLE
Don't use static to mark constexpr variables as link lokal

### DIFF
--- a/include/strong_type/type.hpp
+++ b/include/strong_type/type.hpp
@@ -38,7 +38,7 @@
 namespace strong {
 struct uninitialized_t {
 };
-static constexpr uninitialized_t uninitialized{};
+constexpr uninitialized_t uninitialized{};
 
 template<typename M, typename T>
 using modifier = typename M::template modifier<T>;
@@ -236,7 +236,7 @@ struct require_move_assignable
 };
 
 template <typename ...>
-static constexpr bool always_false = false;
+constexpr bool always_false = false;
 
 template <bool> struct valid_type;
 template <>
@@ -247,11 +247,10 @@ using void_t = void;
 
 
 template <typename Needle, typename Type, typename Modifier>
-static constexpr bool modifier_is
+constexpr bool modifier_is
 = std::is_base_of<modifier<Needle, Type>, modifier<Modifier,Type>>::value;
 
 template <typename Needle, typename Type, typename Haystack>
-static
 constexpr
 bool
     type_implements
@@ -264,7 +263,6 @@ template <
     typename Type,
     typename ... Ms
 >
-static
 constexpr
 bool
 modifier_is<Needle, Type, Modifier<Ms...>>
@@ -276,7 +274,6 @@ template <
     typename Type,
     typename ... Haystack
 >
-static
 constexpr
 bool type_implements<Modifier<Needles...>, Type, Modifier<Haystack...>>
 = (modifier_is<Modifier<Needles>, Type, Modifier<Haystack...>> && ...);
@@ -339,15 +336,15 @@ type_implements<Modifier<Needles...>, Type, Modifier<Haystack...>>
 #endif
 
 template <typename T, typename M>
-static constexpr bool type_is = false;
+constexpr bool type_is = false;
 
 #if __cplusplus >= 201703L
 template <typename T, typename Tag, typename ... Ms, typename M>
-static constexpr bool type_is<strong::type<T, Tag, Ms...>, M>
+constexpr bool type_is<strong::type<T, Tag, Ms...>, M>
     = (impl::type_implements<M, strong::type<T, Tag, Ms...>, Ms> || ...);
 #else
 template <typename T, typename Tag, typename ... Ms, typename M>
-static constexpr bool type_is<strong::type<T, Tag, Ms...>, M>
+constexpr bool type_is<strong::type<T, Tag, Ms...>, M>
     = impl::disjunction<std::integral_constant<bool, impl::type_implements<M, strong::type<T, Tag, Ms...>, Ms>>...>::value;
 #endif
 
@@ -359,7 +356,7 @@ using get_strong = decltype(get_strong_(static_cast<T*>(nullptr)));
 }
 
 template <typename T, typename M>
-static constexpr bool type_is_v = impl::type_is<impl::get_strong<T>, M>;
+constexpr bool type_is_v = impl::type_is<impl::get_strong<T>, M>;
 
 template <typename T, typename M>
 using type_is = std::integral_constant<bool, type_is_v<T,M>>;


### PR DESCRIPTION
Otherwise it is impossible to export types that depend on the strong_type since some of the used templated values are link lokal. Error message from gcc: 
```
out/build/x64-debug-linux/vcpkg_installed/x64-linux/include/strong_type/type.hpp:235:23: note: 'template<class ...> constexpr const bool strong::impl::always_false< <template-parameter-1-1>...>' declared with internal linkage
  235 | static constexpr bool always_false = false;
      |                       ^~~~~~~~~~~~
```
for something like
```c++
module;

#include <strong_type/strong_type.hpp>

export module test;

import std;

using myint = strong::type<int, struct my_int_>;
```
with gcc 15.2